### PR TITLE
feat: página do Saudalos para quiosque Full HD

### DIFF
--- a/saudalos.html
+++ b/saudalos.html
@@ -1,0 +1,384 @@
+---
+permalink: /saudalos/index.html
+---
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=1920, initial-scale=1.0">
+  <title>Saudalos — Criatura Mítica | Emocre × Retrocon</title>
+  <meta name="description" content="Saudalos, a Criatura Mítica exclusiva da Retrocon. Jogue em nosso estande para obter esse Emocre.">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32x32.png">
+  <style>
+    @font-face {
+      font-family: 'emocre';
+      src: url('/assets/emocre.ttf') format('truetype');
+      font-weight: normal;
+      font-style: normal;
+      font-display: block;
+    }
+
+    :root {
+      --ink:      #0b0806;   /* warm near-black */
+      --ink-2:    #17100a;
+      --gold:     #eab308;
+      --gold-hi:  #fbbf24;
+      --amber:    #f59e0b;
+      --ember:    #ff7a18;
+      --joy:      #5aaa30;   /* Alegria */
+      --sadness:  #1aabcc;   /* Tristeza */
+      --cream:    #f6ecd6;
+      --muted:    #c9a86a;
+      --font-game: 'emocre', sans-serif;
+      --font-body: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    html, body {
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      background: #000;
+      cursor: none;
+    }
+
+    /* ── fit the fixed 1920×1080 stage to any screen ── */
+    .viewport {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: radial-gradient(circle at 50% 40%, #140d07 0%, #050302 75%);
+    }
+
+    .stage {
+      position: relative;
+      width: 1920px;
+      height: 1080px;
+      flex: none;
+      transform-origin: center center;
+      overflow: hidden;
+      background:
+        radial-gradient(1200px 900px at 32% 52%, rgba(234,179,8,0.18) 0%, rgba(234,179,8,0.05) 34%, transparent 60%),
+        radial-gradient(1600px 1200px at 50% 50%, #1a1007 0%, #0b0806 55%, #060402 100%);
+      font-family: var(--font-body);
+      color: var(--cream);
+    }
+
+    /* vignette + scanlines + flicker overlays */
+    .stage::before {
+      content: "";
+      position: absolute; inset: 0; z-index: 40; pointer-events: none;
+      background: radial-gradient(ellipse 78% 78% at 50% 50%, transparent 52%, rgba(0,0,0,0.55) 100%);
+    }
+    .stage::after {
+      content: "";
+      position: absolute; inset: 0; z-index: 41; pointer-events: none;
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(0,0,0,0.16) 0px,
+        rgba(0,0,0,0.16) 1px,
+        transparent 2px,
+        transparent 4px
+      );
+      mix-blend-mode: multiply;
+      animation: flicker 5.5s steps(60) infinite;
+    }
+    @keyframes flicker {
+      0%, 96%, 100% { opacity: 1; }
+      97% { opacity: 0.82; }
+      98% { opacity: 1; }
+      99% { opacity: 0.9; }
+    }
+
+    /* ── header row ── */
+    .brandbar {
+      position: absolute; top: 0; left: 0; right: 0; z-index: 20;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 54px 72px 0;
+    }
+    .brandbar img.emocre {
+      height: 74px; width: auto;
+      filter: drop-shadow(0 3px 14px rgba(0,0,0,0.6));
+    }
+    .retro-badge {
+      display: inline-flex; align-items: center; gap: 16px;
+      background: #000;
+      border: 2px solid rgba(234,179,8,0.55);
+      border-radius: 12px;
+      padding: 14px 22px;
+      box-shadow: 0 0 32px rgba(234,179,8,0.25), inset 0 0 0 2px rgba(0,0,0,0.6);
+    }
+    .retro-badge .lbl {
+      font-family: var(--font-game);
+      font-size: 15px; letter-spacing: 0.22em; text-transform: uppercase;
+      color: var(--gold-hi);
+    }
+    .retro-badge img { height: 26px; width: auto; display: block; }
+
+    /* ── main composition ── */
+    .grid {
+      position: absolute; inset: 0; z-index: 10;
+      display: grid;
+      grid-template-columns: 980px 1fr;
+      align-items: center;
+      padding: 0 96px 0 40px;
+    }
+
+    /* left: hero sprite */
+    .hero {
+      position: relative;
+      height: 100%;
+      display: flex; align-items: center; justify-content: center;
+    }
+    /* giant editorial watermark behind sprite */
+    .hero .watermark {
+      position: absolute; left: 50%; top: 50%;
+      transform: translate(-50%, -50%);
+      font-family: var(--font-game);
+      font-size: 300px; line-height: 0.8;
+      color: rgba(234,179,8,0.06);
+      letter-spacing: 0.04em;
+      white-space: nowrap;
+      pointer-events: none;
+      user-select: none;
+    }
+    .hero .aura {
+      position: absolute; left: 50%; top: 50%;
+      width: 760px; height: 760px;
+      transform: translate(-50%, -50%);
+      background: radial-gradient(circle, rgba(245,158,11,0.42) 0%, rgba(234,179,8,0.18) 38%, transparent 68%);
+      border-radius: 50%;
+      filter: blur(6px);
+      animation: aura 4.4s ease-in-out infinite;
+    }
+    @keyframes aura {
+      0%, 100% { opacity: 0.7;  transform: translate(-50%, -50%) scale(1); }
+      50%      { opacity: 1;    transform: translate(-50%, -50%) scale(1.08); }
+    }
+    .hero .ring {
+      position: absolute; left: 50%; top: 50%;
+      width: 640px; height: 640px;
+      transform: translate(-50%, -50%);
+      border-radius: 50%;
+      border: 2px dashed rgba(234,179,8,0.25);
+      animation: spin 46s linear infinite;
+    }
+    @keyframes spin { to { transform: translate(-50%, -50%) rotate(360deg); } }
+
+    .hero img.sprite {
+      position: relative; z-index: 2;
+      height: 720px; width: auto;
+      image-rendering: pixelated;
+      filter: drop-shadow(0 30px 44px rgba(0,0,0,0.6)) drop-shadow(0 0 40px rgba(245,158,11,0.28));
+      animation: float 5.2s ease-in-out infinite;
+    }
+    @keyframes float {
+      0%, 100% { transform: translateY(0); }
+      50%      { transform: translateY(-26px); }
+    }
+    /* reflection plinth */
+    .hero .plinth {
+      position: absolute; left: 50%; bottom: 150px;
+      width: 560px; height: 60px;
+      transform: translateX(-50%);
+      background: radial-gradient(ellipse at center, rgba(0,0,0,0.55) 0%, transparent 70%);
+      z-index: 1;
+    }
+
+    /* right: info */
+    .info { padding-right: 24px; }
+
+    .kicker {
+      display: inline-flex; align-items: center; gap: 14px;
+      font-family: var(--font-game);
+      font-size: 22px; letter-spacing: 0.28em; text-transform: uppercase;
+      color: var(--gold-hi);
+      margin-bottom: 26px;
+    }
+    .kicker .dot {
+      width: 14px; height: 14px; border-radius: 50%;
+      background: var(--gold-hi);
+      box-shadow: 0 0 16px var(--gold-hi);
+      animation: pulse 1.8s ease-in-out infinite;
+    }
+    @keyframes pulse { 0%,100%{opacity:.45;transform:scale(.85);} 50%{opacity:1;transform:scale(1.15);} }
+
+    .name {
+      font-family: var(--font-game);
+      font-size: 168px; line-height: 0.9;
+      color: var(--gold);
+      letter-spacing: 0.01em;
+      text-shadow:
+        0 0 2px rgba(255,255,255,0.4),
+        0 6px 0 #7a4d05,
+        0 10px 40px rgba(234,179,8,0.55);
+      margin-bottom: 30px;
+    }
+
+    .subrow {
+      display: flex; align-items: center; gap: 28px;
+      margin-bottom: 40px;
+    }
+    .emotion {
+      font-family: var(--font-game);
+      font-size: 26px; letter-spacing: 0.22em; text-transform: uppercase;
+      color: var(--ember);
+    }
+    .lvl {
+      font-family: var(--font-game);
+      font-size: 22px;
+      color: var(--joy);
+      border: 2px solid rgba(90,170,48,0.5);
+      background: rgba(90,170,48,0.1);
+      border-radius: 10px;
+      padding: 10px 20px;
+    }
+
+    .types { display: flex; gap: 20px; margin-bottom: 46px; }
+    .type {
+      font-family: var(--font-game);
+      font-size: 24px; letter-spacing: 0.06em;
+      color: #fff;
+      padding: 16px 34px;
+      border-radius: 12px;
+      box-shadow: 0 8px 22px rgba(0,0,0,0.4);
+    }
+    .type.al { background: var(--joy); }
+    .type.tr { background: var(--sadness); }
+
+    .desc {
+      font-size: 30px; line-height: 1.55;
+      color: var(--muted);
+      max-width: 720px;
+      margin-bottom: 60px;
+    }
+    .desc strong { color: var(--cream); font-weight: 600; }
+
+    /* ── the CTA ── */
+    .cta {
+      position: relative;
+      display: flex; align-items: center; justify-content: center;
+      text-align: center;
+      background: linear-gradient(135deg, var(--gold-hi) 0%, var(--amber) 52%, var(--ember) 100%);
+      border-radius: 20px;
+      padding: 44px 60px;
+      max-width: 820px;
+      box-shadow: 0 20px 60px rgba(245,158,11,0.4), inset 0 2px 0 rgba(255,255,255,0.35);
+      overflow: hidden;
+    }
+    .cta::after {
+      content: "";
+      position: absolute; top: 0; left: -40%; width: 40%; height: 100%;
+      background: linear-gradient(100deg, transparent, rgba(255,255,255,0.55), transparent);
+      transform: skewX(-18deg);
+      animation: sheen 3.6s ease-in-out infinite;
+    }
+    @keyframes sheen {
+      0%   { left: -50%; }
+      55%  { left: 130%; }
+      100% { left: 130%; }
+    }
+    .cta .cta-text {
+      font-family: var(--font-game);
+      font-size: 34px; line-height: 1.3;
+      color: #1a0f03;
+      letter-spacing: 0.01em;
+    }
+    .cta .cta-text b { display: block; font-size: 40px; }
+
+    /* floating sparkles */
+    .spark {
+      position: absolute; z-index: 15;
+      color: var(--gold-hi);
+      opacity: 0.8;
+      animation: twinkle 3s ease-in-out infinite;
+      filter: drop-shadow(0 0 8px rgba(234,179,8,0.6));
+    }
+    .spark svg { display: block; }
+    @keyframes twinkle {
+      0%,100% { opacity: 0.15; transform: scale(0.7) rotate(0deg); }
+      50%     { opacity: 0.9;  transform: scale(1.1) rotate(20deg); }
+    }
+    .s1 { top: 150px; left: 880px; animation-delay: 0s;   }
+    .s2 { top: 720px; left: 250px; animation-delay: 0.9s; }
+    .s3 { top: 300px; left: 120px; animation-delay: 1.7s; }
+    .s4 { top: 830px; left: 780px; animation-delay: 0.4s; }
+    .s5 { top: 90px;  left: 560px; animation-delay: 2.3s; }
+  </style>
+</head>
+<body>
+  <div class="viewport">
+    <div class="stage" id="stage">
+
+      <div class="brandbar">
+        <img class="emocre" src="/assets/logo.png" alt="Emocre" />
+        <div class="retro-badge">
+          <span class="lbl">Exclusivo</span>
+          <img src="/assets/retrocon-logo.png" alt="Retrocon" />
+        </div>
+      </div>
+
+      <!-- sparkles -->
+      <div class="spark s1"><svg width="46" height="46" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l2.4 4.9 5.3.8-3.8 3.7.9 5.3-4.8-2.5-4.8 2.5.9-5.3-3.8-3.7 5.3-.8z"/></svg></div>
+      <div class="spark s2"><svg width="30" height="30" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l2.4 4.9 5.3.8-3.8 3.7.9 5.3-4.8-2.5-4.8 2.5.9-5.3-3.8-3.7 5.3-.8z"/></svg></div>
+      <div class="spark s3"><svg width="36" height="36" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l2.4 4.9 5.3.8-3.8 3.7.9 5.3-4.8-2.5-4.8 2.5.9-5.3-3.8-3.7 5.3-.8z"/></svg></div>
+      <div class="spark s4"><svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l2.4 4.9 5.3.8-3.8 3.7.9 5.3-4.8-2.5-4.8 2.5.9-5.3-3.8-3.7 5.3-.8z"/></svg></div>
+      <div class="spark s5"><svg width="40" height="40" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l2.4 4.9 5.3.8-3.8 3.7.9 5.3-4.8-2.5-4.8 2.5.9-5.3-3.8-3.7 5.3-.8z"/></svg></div>
+
+      <div class="grid">
+        <!-- LEFT: hero sprite -->
+        <div class="hero">
+          <div class="watermark">MÍTICO</div>
+          <div class="aura"></div>
+          <div class="ring"></div>
+          <div class="plinth"></div>
+          <img class="sprite" src="/assets/creatures/longing-1-art-front-crt.gif" alt="Saudalos" />
+        </div>
+
+        <!-- RIGHT: info -->
+        <div class="info">
+          <span class="kicker"><span class="dot"></span>Criatura Mítica</span>
+          <h1 class="name">Saudalos</h1>
+          <div class="subrow">
+            <span class="emotion">Saudade</span>
+            <span class="lvl">Nível 5</span>
+          </div>
+          <div class="types">
+            <span class="type al">Alegria</span>
+            <span class="type tr">Tristeza</span>
+          </div>
+          <p class="desc">
+            Vagaroso pelas profundezas, seus olhos projetam uma luz trêmula
+            que ilumina <strong>coisas que não existem mais</strong>.
+          </p>
+
+          <div class="cta">
+            <span class="cta-text">
+              Jogue em nosso estande
+              <b>para obter esse Emocre</b>
+            </span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <script>
+    // Scale the fixed 1920×1080 stage to fit whatever the kiosk resolution is,
+    // keeping aspect ratio (letterboxes only if the display isn't 16:9).
+    (function () {
+      var stage = document.getElementById('stage');
+      function fit() {
+        var s = Math.min(window.innerWidth / 1920, window.innerHeight / 1080);
+        stage.style.transform = 'scale(' + s + ')';
+      }
+      window.addEventListener('resize', fit);
+      fit();
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Página standalone em `/saudalos/` para o quiosque Full HD (1920×1080) do evento.

- Estética Retrocon/CRT: fundo escuro, scanlines, vinheta, glow dourado
- Sprite gigante do Saudalos com aura pulsante e anel giratório
- Badge "Exclusivo Retrocon", tipos Alegria/Tristeza, Nível 5
- CTA em destaque: "Jogue em nosso estande para obter esse Emocre"
- Escala para preencher qualquer tela 16:9; sem nav do site nem interação

🤖 Generated with [Claude Code](https://claude.com/claude-code)